### PR TITLE
Bug fixes and add Fanotify Tests

### DIFF
--- a/fanotify_api.go
+++ b/fanotify_api.go
@@ -38,7 +38,7 @@ type Event struct {
 	// Mask holds bit mask representing the operation
 	Mask Action
 	// Pid Process ID of the process that caused the event
-	Pid int32
+	Pid int
 }
 
 // Listener represents a fanotify notification group that holds a list of files,

--- a/fanotify_event.go
+++ b/fanotify_event.go
@@ -361,7 +361,7 @@ func (l *Listener) readEvents() error {
 					Fd:   int(metadata.Fd),
 					Path: string(name[:n1]),
 					Mask: Action(mask),
-					Pid:  metadata.Pid,
+					Pid:  int(metadata.Pid),
 				}
 				l.Events <- event
 
@@ -408,7 +408,7 @@ func (l *Listener) readEvents() error {
 					Path:     pathName,
 					FileName: fileName,
 					Mask:     Action(mask),
-					Pid:      metadata.Pid,
+					Pid:      int(metadata.Pid),
 				}
 				l.Events <- event
 				i += int(metadata.Event_len)

--- a/fanotify_test.go
+++ b/fanotify_test.go
@@ -81,7 +81,7 @@ func TestFanotifyFileAccessed(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Error("Timeout Error: FileOrDirectoryAccessed event not received")
 	case event := <-l.Events:
-		assert.Equal(t, event.Path, testFile)
+		assert.Equal(t, fmt.Sprintf("%s/%s", event.Path, event.FileName), testFile)
 		assert.Equal(t, event.Pid, pid)
 		hasFileAccessed := (event.Mask & FileAccessed) == FileAccessed
 		assert.True(t, hasFileAccessed)

--- a/fanotify_test.go
+++ b/fanotify_test.go
@@ -60,7 +60,7 @@ func catFile(filename string) (int, error) {
 }
 
 func modifyFile(filename string) (int, error) {
-	cmd := exec.Command("sed", "-i", "s/\\(.*\\)/\\U\\1/", filename)
+	cmd := exec.Command("touch", "-m", filename)
 	err := cmd.Run()
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
- Change Event.Pid to `int` from `int32`
- If present, unset unix.FAN_ONDIR from mask
- Test fanotify events
  - test file or directory accessed event
  - test file modified event

The file modification event triggered from the kernel seems to populate incorrect (parent pid) into `fanotiffy_event_metadata.pid` instead of the process that modified the file. (https://bugzilla.kernel.org/show_bug.cgi?id=216775)
  